### PR TITLE
Update/drop support for python 2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Example of a CODEOWNERS file
+
+# Specify owners for the entire repository
+* @nicholasbunn @isabellanorris

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# djangorestframework-recursive
+# Django Rest Framework Recursive (Fork)
+
+This repository is the friendly fork of the original [django-rest-framework-recursive](https://github.com/heywbj/django-rest-framework-recursive) by [heywbj](https://github.com/heywbj). As the original repo is no longer being actively maintained, we've friendly forked it here to undertake on maintenance for modern versions of Python, Django, and Django Rest Framework.
 
 [![build-status-image]][travis]
 [![pypi-version]][pypi]
@@ -8,11 +10,13 @@
 Recursive Serialization for Django REST framework
 
 This package provides a `RecursiveField` that enables you to serialize a tree,
-linked list, or even a directed acyclic graph. Also supports validation,
+linked list, or even a directed acyclic graph. It also supports validation,
 deserialization, ModelSerializers, and multi-step recursive structures.
 
 
-## Example
+## Examples
+
+### Tree Recursion
 
 ```python
 from rest_framework import serializers
@@ -23,8 +27,18 @@ class TreeSerializer(serializers.Serializer):
     children = serializers.ListField(child=RecursiveField())
 ```
 
-see [**here**][tests] for more usage examples
+### Linked List Recursion
+```python
+from rest_framework import serializers
+from rest_framework_recursive.fields import RecursiveField
 
+class LinkSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=25)
+    next = RecursiveField(allow_null=True)
+```
+
+
+Further use cases are documented in the tests, see [**here**][tests] for more usage examples
 
 ## Requirements
 
@@ -37,8 +51,8 @@ see [**here**][tests] for more usage examples
 
 Install using `pip`...
 
-```bash
-$ pip install djangorestframework-recursive
+```
+pip install django-rest-framework-recursive
 ```
 
 ## Release notes
@@ -53,20 +67,20 @@ $ pip install djangorestframework-recursive
 
 Install testing requirements.
 
-```bash
-$ pip install -r requirements.txt
+```
+pip install -r requirements.txt
 ```
 
 Run with runtests.
 
-```bash
-$ ./runtests.py
+```
+./runtests.py
 ```
 
-You can also use the excellent [tox](http://tox.readthedocs.org/en/latest/) testing tool to run the tests against all supported versions of Python and Django. Install tox globally, and then simply run:
+You can also use [tox](http://tox.readthedocs.org/en/latest/) to run the tests against all supported versions of Python and Django. Install tox globally with `pip install tox`, and then simply run:
 
-```bash
-$ tox
+```
+tox
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 # Minimum Django and REST framework version
-Django>=1.6
-djangorestframework>=3.0.0
+Django>=1.6; python_version <= '3.6'
+
+djangorestframework>=3.0.0; python_version <= '3.6'
 
 # Test requirements
-pytest-django==2.9.1
-pytest==2.8.5
+pytest-django==2.9.1; python_version <= '3.6'
+
+pytest==2.8.5; python_version <= '3.6'
+
 pytest-cov==2.2.0
 
 # wheel for PyPI installs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Minimum Django and REST framework version
-Django>=4.0; python_version >= '3.10'
+Django>=3.2; python_version >= '3.10'
 
-djangorestframework>=3.15.0; python_version >= '3.10'
+djangorestframework>=3.12.0; python_version >= '3.10'
 
 # Test requirements
-pytest-django==4.7.0; python_version <= '3.10'
+pytest-django==4.7.0; python_version >= '3.10'
 
-pytest==8.3.2; python_version <= '3.10'
+pytest==8.3.2; python_version >= '3.10'
 
 pytest-cov==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
 # Minimum Django and REST framework version
 Django>=1.6; python_version <= '3.6'
+Django>=4.0; python_version >= '3.10'
 
 djangorestframework>=3.0.0; python_version <= '3.6'
+djangorestframework>=3.15.0; python_version >= '3.10'
 
 # Test requirements
 pytest-django==2.9.1; python_version <= '3.6'
+pytest-django==4.7.0; python_version >= '3.7' and python_version <= '3.10'
 
 pytest==2.8.5; python_version <= '3.6'
+pytest==8.3.2; python_version >= '3.8' and python_version <= '3.10'
 
 pytest-cov==2.2.0
-
-# wheel for PyPI installs
-wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,11 @@
 # Minimum Django and REST framework version
-Django>=1.6; python_version <= '3.6'
 Django>=4.0; python_version >= '3.10'
 
-djangorestframework>=3.0.0; python_version <= '3.6'
 djangorestframework>=3.15.0; python_version >= '3.10'
 
 # Test requirements
-pytest-django==2.9.1; python_version <= '3.6'
-pytest-django==4.7.0; python_version >= '3.7' and python_version <= '3.10'
+pytest-django==4.7.0; python_version <= '3.10'
 
-pytest==2.8.5; python_version <= '3.6'
-pytest==8.3.2; python_version >= '3.8' and python_version <= '3.10'
+pytest==8.3.2; python_version <= '3.10'
 
 pytest-cov==2.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-       py{34,35,36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
+       py{27,34,35,36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
+       py{310}-django{4}-drf{3.15}
 [testenv]
 allowlist_externals = python
 commands = python ./runtests.py --fast
@@ -11,8 +12,11 @@ deps =
        django1.9: Django>=1.9,<1.10; python_version <= '3.6'
        django1.10: Django>=1.10,<1.11; python_version <= '3.6'
        django1.11: Django>=1.11,<2.0; python_version <= '3.6'
+       django4: Django>=4.0,<5.0; python_version >= '3.10'
        drf3.3: djangorestframework>=3.3,<3.4; python_version <= '3.6'
        drf3.4: djangorestframework>=3.4,<3.5; python_version <= '3.6'
        drf3.5: djangorestframework>=3.5,<3.6; python_version <= '3.6'
        drf3.6: djangorestframework>=3.6,<3.7; python_version <= '3.6'
+       drf3.15: djangorestframework>=3.15,<3.16; python_version >= '3.10'
        pytest-django==3.1.2; python_version <= '3.6'
+       pytest-django==4.7.0; python_version >= '3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,26 @@
 [tox]
-envlist =
-       py{310}-django{4}-drf{3.15}
+envlist = 
+    py310-django{32}-drf{312} # DRF 3.12 is not supported beyond Django 3.2 so it's getting it's own configuration here
+    py310-django{32,40,41,42}-drf{313,314,315}
+    py310-django{5}-drf{314,315} # Django 5 is not supported for DRF < 3.13 so it's getting it's own configuration here
+
 [testenv]
 allowlist_externals = python
 commands = python ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
+basepython =
+    py310: python3.10
 deps =
-       django4: Django>=4.0,<5.0; python_version >= '3.10'
-       drf3.15: djangorestframework>=3.15,<3.16; python_version >= '3.10'
-       pytest-django==4.7.0; python_version >= '3.10'
+    django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
+    django5: Django>=5.0,<5.1
+
+    drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
+    drf314: djangorestframework>=3.14,<3.15
+    drf315: djangorestframework>=3.15,<3.16
+
+    pytest-django==4.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-       py{27,34,35,36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
        py{310}-django{4}-drf{3.15}
 [testenv]
 allowlist_externals = python
@@ -8,15 +7,6 @@ commands = python ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.8: Django>=1.8,<1.9; python_version <= '3.6'
-       django1.9: Django>=1.9,<1.10; python_version <= '3.6'
-       django1.10: Django>=1.10,<1.11; python_version <= '3.6'
-       django1.11: Django>=1.11,<2.0; python_version <= '3.6'
        django4: Django>=4.0,<5.0; python_version >= '3.10'
-       drf3.3: djangorestframework>=3.3,<3.4; python_version <= '3.6'
-       drf3.4: djangorestframework>=3.4,<3.5; python_version <= '3.6'
-       drf3.5: djangorestframework>=3.5,<3.6; python_version <= '3.6'
-       drf3.6: djangorestframework>=3.6,<3.7; python_version <= '3.6'
        drf3.15: djangorestframework>=3.15,<3.16; python_version >= '3.10'
-       pytest-django==3.1.2; python_version <= '3.6'
        pytest-django==4.7.0; python_version >= '3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-       {py27,py34,py35,py36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
-
+       {py34,py35,py36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
 [testenv]
 commands = ./runtests.py --fast
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
 envlist =
-       {py34,py35,py36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
+       py{34,35,36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
 [testenv]
-commands = ./runtests.py --fast
+allowlist_externals = python
+commands = python ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.8: Django>=1.8,<1.9
-       django1.9: Django>=1.9,<1.10
-       django1.10: Django>=1.10,<1.11
-       django1.11: Django>=1.11,<2.0
-       drf3.3: djangorestframework>=3.3,<3.4
-       drf3.4: djangorestframework>=3.4,<3.5
-       drf3.5: djangorestframework>=3.5,<3.6
-       drf3.6: djangorestframework>=3.6,<3.7
-       pytest-django==3.1.2
+       django1.8: Django>=1.8,<1.9; python_version <= '3.6'
+       django1.9: Django>=1.9,<1.10; python_version <= '3.6'
+       django1.10: Django>=1.10,<1.11; python_version <= '3.6'
+       django1.11: Django>=1.11,<2.0; python_version <= '3.6'
+       drf3.3: djangorestframework>=3.3,<3.4; python_version <= '3.6'
+       drf3.4: djangorestframework>=3.4,<3.5; python_version <= '3.6'
+       drf3.5: djangorestframework>=3.5,<3.6; python_version <= '3.6'
+       drf3.6: djangorestframework>=3.6,<3.7; python_version <= '3.6'
+       pytest-django==3.1.2; python_version <= '3.6'


### PR DESCRIPTION
Just dropping Python 2 support for this and adding 3.10 support before refactoring the repo to follow our cookie-cutter pattern. Setting up Nox and integrating things is going to be a lot easier once I've made this update!

Tox report for this PR is passing:
<img width="470" alt="Screenshot 2024-08-14 at 16 19 17" src="https://github.com/user-attachments/assets/e7a55d70-2cb7-4d33-9b4b-1b1508f89f19">
