### PR TITLE
Update package name

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/django-rest-framework-recursive
+      url: https://pypi.org/p/drf-recursive
     timeout-minutes: 5
 
     permissions:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ During development you will also need:
 Install using `pip`...
 
 ```
-pip install django-rest-framework-recursive
+pip install drf-recursive
 ```
 
 ## Local development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ where = ["src"]
 # -------
 
 [project]
-name = "django-rest-framework-recursive"
+name = "drf-recursive"
 
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [tool.bumpversion] section.


### PR DESCRIPTION
The deployment to PyPi failed due to name similarity with the original `djangorestframework-recursive`.

This PR changes the package name from `django-rest-framework-recursive` to `drf-recursive`, looking at the similarity algorithm this _should_ be fine
