### PR TITLE
Update/specify readme for package build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This package supports:
 - Django 3.2, 4.0, 4.1, 4.2, 5.0
 - Django Rest Framework 3.12, 3.13, 3.14, 3.15
 
-For an exact list of tested version combinations, see the `valid_version_combinations` set in the [noxfile](./noxfile.py)
+For an exact list of tested version combinations, see the `valid_version_combinations` set in the [noxfile](https://github.com/kraken-tech/django-rest-framework-recursive/blob/master/noxfile.py)
 
 During development you will also need:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ where = ["src"]
 
 [project]
 name = "drf-recursive"
+readme = "README.md"
 
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [tool.bumpversion] section.


### PR DESCRIPTION
For some reason this didn't cause an error in other tests I've run, but we have to specify the README file here so that it knows to expect a markdown file rather than an RST it seems.

Here's the Twine check passing. This command failed before making these changes with the [same error](https://github.com/kraken-tech/django-rest-framework-recursive/actions/runs/10524405915/job/29161080712) I received in the workflow action, so these updates should fix it:

![Screenshot 2024-08-23 at 12 13 52](https://github.com/user-attachments/assets/be1c81c5-74d0-460d-8a7b-0989c5d45635)
