### PR TITLE
Remove repository_url for publishing to PyPi

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -52,5 +52,3 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://pypi.org/legacy/


### PR DESCRIPTION
Legacy endpoint was documented incorrectly [here](https://github.com/pypa/gh-action-pypi-publish/blob/8ef2b3d46c9ecba901fb2ae21d98e322c4089c4e/action.yml#L23), it should have been `https://upload.pypi.org/legacy/` not `https://pypi.org/legacy/`. Removing this should force it to use whatever the current default specified in the `gh-action-pypi-publish` release is.