### PR TITLE
Update/dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- Moved the dependencies for test packages (`pytest`, `pytest-django`, `pytest-cov`) into dev dependencies.
+
+### Removed
+
 ## [0.3.0] - 2024-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-09-03
+
 ### Added
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ readme = "README.md"
 
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [tool.bumpversion] section.
-version = "0.3.0"
+version = "0.3.1"
 dependencies = ["django>=3.2", "djangorestframework>=3.12.0"]
 
 [project.urls]
@@ -132,7 +132,7 @@ filterwarnings = "error"
 [tool.bumpversion]
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [project] section.
-current_version = "0.3.0"
+current_version = "0.3.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,7 @@ readme = "README.md"
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [tool.bumpversion] section.
 version = "0.3.0"
-dependencies = [
-    "django>=3.2",
-    "djangorestframework>=3.12.0",
-    "pytest-django==4.7.0",
-    "pytest==8.3.2",
-    "pytest-cov",
-]
+dependencies = ["django>=3.2", "djangorestframework>=3.12.0"]
 
 [project.urls]
 # See https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet for
@@ -44,7 +38,9 @@ changelog = "https://github.com/kraken-tech/django-rest-framework-recursive/blob
 dev = [
     # Testing
     "pytest",
-    "nox",    # Install in virtualenv so Mypy has access to the package types.
+    "pytest-django>=4.7.0",
+    "pytest-cov",
+    "nox",                  # Install in virtualenv so Mypy has access to the package types.
 
     # Linting
     "ruff",


### PR DESCRIPTION
This PR moves the dependencies for `pytest`, `pytest-django`, and `pytets-cov` from a required dependency to a dev dependency.

It also bumps to v0.3.1

Nox report:
<img width="937" alt="Screenshot 2024-09-03 at 09 06 57" src="https://github.com/user-attachments/assets/0358e412-14ea-4d0a-ab9b-1a1e12ac43f3">

Twine Check:
<img width="653" alt="Screenshot 2024-09-03 at 09 14 57" src="https://github.com/user-attachments/assets/0ebe58e6-fa12-4090-a440-5388e24edb03">
