### PR TITLE
Update/add support for python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Further use cases are documented in the tests, see [**here**][tests] for more us
 This package supports:
 
 - Python 3.10, 3.11
-- Django 3.2, 4.0, 4.1, 4.2, 5.0
+- Django 3.2, 4.0, 4.1, 4.2, 5.0, 5.1
 - Django Rest Framework 3.12, 3.13, 3.14, 3.15
 
 For an exact list of tested version combinations, see the `valid_version_combinations` set in the [noxfile](https://github.com/kraken-tech/django-rest-framework-recursive/blob/master/noxfile.py)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Further use cases are documented in the tests, see [**here**][tests] for more us
 
 This package supports:
 
-- Python 3.10, 3.11
+- Python 3.10, 3.11, 3.12
 - Django 3.2, 4.0, 4.1, 4.2, 5.0, 5.1
 - Django Rest Framework 3.12, 3.13, 3.14, 3.15
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,6 +44,7 @@ valid_version_combinations = [
     ("3.11", "django>=4.2,<4.3", "djangorestframework>=3.15,<3.16"),
     ("3.11", "django>=5.0,<5.1", "djangorestframework>=3.14,<3.15"),
     ("3.11", "django>=5.0,<5.1", "djangorestframework>=3.15,<3.16"),
+    ("3.11", "django>=5.1,<5.2", "djangorestframework>=3.15,<3.16"),
 ]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,15 @@ valid_version_combinations = [
     ("3.11", "django>=5.0,<5.1", "djangorestframework>=3.14,<3.15"),
     ("3.11", "django>=5.0,<5.1", "djangorestframework>=3.15,<3.16"),
     ("3.11", "django>=5.1,<5.2", "djangorestframework>=3.15,<3.16"),
+    # Python 3.12
+    ("3.12", "django>=4.1,<4.2", "djangorestframework>=3.14,<3.15"),
+    ("3.12", "django>=4.1,<4.2", "djangorestframework>=3.15,<3.16"),
+    ("3.12", "django>=4.2,<4.3", "djangorestframework>=3.14,<3.15"),
+    ("3.12", "django>=4.2,<4.3", "djangorestframework>=3.15,<3.16"),
+    ("3.12", "django>=5.0,<5.1", "djangorestframework>=3.14,<3.15"),
+    ("3.12", "django>=5.0,<5.1", "djangorestframework>=3.15,<3.16"),
+    ("3.12", "django>=5.1,<5.2", "djangorestframework>=3.14,<3.15"),
+    ("3.12", "django>=5.1,<5.2", "djangorestframework>=3.15,<3.16"),
 ]
 
 


### PR DESCRIPTION
Adds tested support for Python 3.12. In doing this we have also added tested support for Django 5.1 for both Python 3.11 & Python 3.12

Nox report:
<img width="950" alt="Screenshot 2024-09-23 at 16 04 31" src="https://github.com/user-attachments/assets/bfaa5022-2098-46ca-b468-eac079a73b06">

