### PR TITLE
Release/v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-10-03
+
 ### Added
 
 - Tested support for Python 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Tested support for Python 3.12
+- Tested support for Django versions 5.1
+
+### Changed
+
+### Removed
+
 ## [0.3.1] - 2024-09-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ readme = "README.md"
 
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [tool.bumpversion] section.
-version = "0.3.1"
+version = "0.4.0"
 dependencies = ["django>=3.2", "djangorestframework>=3.12.0"]
 
 [project.urls]
@@ -132,7 +132,7 @@ filterwarnings = "error"
 [tool.bumpversion]
 # Do not manually edit the version, use `make version_{type}` instead.
 # This should match the version in the [project] section.
-current_version = "0.3.1"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"


### PR DESCRIPTION
Creates a release for V0.4.0 (adding support for Python 3.12 & Django 5.1)

Nox Report:
<img width="953" alt="Screenshot 2024-10-03 at 16 24 24" src="https://github.com/user-attachments/assets/b7afe018-7f2a-4128-a02b-ae9dd8fc501e">

Twine Check:
<img width="505" alt="Screenshot 2024-10-03 at 16 25 07" src="https://github.com/user-attachments/assets/75f241df-3061-4050-bdbd-ff9ccc1745d0">
