### PR TITLE
Update/add support for python 3.13

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,9 @@ valid_version_combinations = [
     ("3.11", "django>=5.0,<5.1", "djangorestframework>=3.14,<3.15"),
     ("3.11", "django>=5.0,<5.1", "djangorestframework>=3.15,<3.16"),
     ("3.11", "django>=5.1,<5.2", "djangorestframework>=3.15,<3.16"),
+    ("3.11", "django>=5.1,<5.2", "djangorestframework>=3.16,<3.17"),
+    ("3.11", "django>=5.2,<5.3", "djangorestframework>=3.15,<3.16"),
+    ("3.11", "django>=5.2,<5.3", "djangorestframework>=3.16,<3.17"),
     # Python 3.12
     ("3.12", "django>=4.1,<4.2", "djangorestframework>=3.14,<3.15"),
     ("3.12", "django>=4.1,<4.2", "djangorestframework>=3.15,<3.16"),

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,6 @@ from typing import IO, Generator
 
 import nox
 
-
 # Use uv to manage venvs.
 nox.options.default_venv_backend = "uv"
 
@@ -61,6 +60,19 @@ valid_version_combinations = [
     ("3.12", "django>=5.2,<5.3", "djangorestframework>=3.14,<3.15"),
     ("3.12", "django>=5.2,<5.3", "djangorestframework>=3.15,<3.16"),
     ("3.12", "django>=5.2,<5.3", "djangorestframework>=3.16,<3.17"),
+    # Python 3.13
+    ("3.13", "django>=4.1,<4.2", "djangorestframework>=3.14,<3.15"),
+    ("3.13", "django>=4.1,<4.2", "djangorestframework>=3.15,<3.16"),
+    ("3.13", "django>=4.2,<4.3", "djangorestframework>=3.14,<3.15"),
+    ("3.13", "django>=4.2,<4.3", "djangorestframework>=3.15,<3.16"),
+    ("3.13", "django>=5.0,<5.1", "djangorestframework>=3.14,<3.15"),
+    ("3.13", "django>=5.0,<5.1", "djangorestframework>=3.15,<3.16"),
+    ("3.13", "django>=5.1,<5.2", "djangorestframework>=3.14,<3.15"),
+    ("3.13", "django>=5.1,<5.2", "djangorestframework>=3.15,<3.16"),
+    ("3.13", "django>=5.1,<5.2", "djangorestframework>=3.16,<3.17"),
+    ("3.13", "django>=5.2,<5.3", "djangorestframework>=3.14,<3.15"),
+    ("3.13", "django>=5.2,<5.3", "djangorestframework>=3.15,<3.16"),
+    ("3.13", "django>=5.2,<5.3", "djangorestframework>=3.16,<3.17"),
 ]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,6 +57,10 @@ valid_version_combinations = [
     ("3.12", "django>=5.0,<5.1", "djangorestframework>=3.15,<3.16"),
     ("3.12", "django>=5.1,<5.2", "djangorestframework>=3.14,<3.15"),
     ("3.12", "django>=5.1,<5.2", "djangorestframework>=3.15,<3.16"),
+    ("3.12", "django>=5.1,<5.2", "djangorestframework>=3.16,<3.17"),
+    ("3.12", "django>=5.2,<5.3", "djangorestframework>=3.14,<3.15"),
+    ("3.12", "django>=5.2,<5.3", "djangorestframework>=3.15,<3.16"),
+    ("3.12", "django>=5.2,<5.3", "djangorestframework>=3.16,<3.17"),
 ]
 
 


### PR DESCRIPTION
Adds tested support for Python 3.13. In doing this we have also added tested support for Django 5.2 and Django Rest Framework 3.17 for Python 3.11, Python 3.12 & Python 3.13

<img width="508" alt="Screenshot 2025-05-02 at 9 51 56 am" src="https://github.com/user-attachments/assets/4cea5beb-b33f-4ae0-97e1-7ed5888f3ac0" />
